### PR TITLE
Partial support for directory as array

### DIFF
--- a/modules/smart_contract_connector/lib/impl.js
+++ b/modules/smart_contract_connector/lib/impl.js
@@ -374,6 +374,16 @@ module.exports = function (config, cached) {
             directory = 'legalEntity';
         } else if(orgidType == 'organizationalUnit') {
             directory = jsonContent.organizationalUnit.type;
+            // Directory should be an array
+            // But Database expects a string
+            if(Array.isArray(directory)) {
+                // Backward compatibility for Arbor BE
+                if(directory.length === 1) {
+                    directory = directory[0];
+                } else {
+                    directory = JSON.stringify(directory);
+                }
+            }
         }
         
         // Retrieve name


### PR DESCRIPTION
Directories should be an array as per JSON schema, but Database expects a string.
- If array contains a single element, directory is stored as string
- If more than one element, directory is stored as JSON

More work will be needed in backend